### PR TITLE
allow for config tokens with extra whitespace

### DIFF
--- a/app/models/token_auth/configuration_token.rb
+++ b/app/models/token_auth/configuration_token.rb
@@ -15,10 +15,14 @@ module TokenAuth
     # Returns case insensitive match.
     # rubocop:disable Rails/FindBy
     def self.find_match(value)
-      return nil unless value.is_a?(String) && value.length == TOKEN_LENGTH
+      return nil unless value.is_a?(String)
+
+      query = value.gsub(/[\s]+/, "")
+
+      return nil unless query.length == TOKEN_LENGTH
 
       where(arel_table[:expires_at].gt(Time.zone.now))
-        .where(arel_table[:value].matches(value))
+        .where(arel_table[:value].matches(query))
         .first
     end
     # rubocop:enable Rails/FindBy

--- a/spec/models/token_auth/configuration_token_spec.rb
+++ b/spec/models/token_auth/configuration_token_spec.rb
@@ -35,6 +35,14 @@ module TokenAuth
         query = "a" * ConfigurationToken::TOKEN_LENGTH
         expect(ConfigurationToken.find_match(query)).not_to be_nil
       end
+
+      it "returns records with mismatched whitespace in the query" do
+        token = create_token!
+        query = token.value.clone
+        query.insert(2, "\t").insert(4, "   ")
+
+        expect(ConfigurationToken.find_match(query)).not_to be_nil
+      end
     end
 
     describe "#make_authentication_token" do


### PR DESCRIPTION
- for some characters, browser/phone settings add extra whitespace, such
  as '$'
