### PR TITLE
Ecf 113847619 config token valid period

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -37,7 +37,7 @@ end
 desc "Run MarkDown lint"
 task :mdl do
   results = `#{ File.join(dir, "bin", "mdl") } #{ File.join(dir, ".") }`
-  if results.strip.length > 0
+  unless results.strip.empty?
     puts results
     exit 1
   end

--- a/app/controllers/token_auth/api/payloads_controller.rb
+++ b/app/controllers/token_auth/api/payloads_controller.rb
@@ -53,7 +53,7 @@ module TokenAuth
 
         return if @authentication_token
 
-        fail TokenAuth::Concerns::ApiResources::Api::Unauthorized
+        raise TokenAuth::Concerns::ApiResources::Api::Unauthorized
       end
 
       def calculate_signature
@@ -70,7 +70,7 @@ module TokenAuth
 
       def split_header
         if request.headers[:Authorization].nil?
-          fail TokenAuth::Concerns::ApiResources::Api::Unauthorized
+          raise TokenAuth::Concerns::ApiResources::Api::Unauthorized
         end
 
         auth_headers = request.headers[:Authorization].split(",")
@@ -86,7 +86,7 @@ module TokenAuth
 
         return if @metadata[:signature] == calculate_signature
 
-        fail TokenAuth::Concerns::ApiResources::Api::Unauthorized
+        raise TokenAuth::Concerns::ApiResources::Api::Unauthorized
       end
 
       def find_pullable_resources(entity_id)

--- a/app/controllers/token_auth/concerns/api_resources.rb
+++ b/app/controllers/token_auth/concerns/api_resources.rb
@@ -31,7 +31,7 @@ module TokenAuth
                                 .find_enabled(client_uuid: client_uuid,
                                               value: auth_header)
 
-        fail Api::Unauthorized unless @authentication_token
+        raise Api::Unauthorized unless @authentication_token
       end
 
       def client_uuid

--- a/app/models/token_auth/configuration_token.rb
+++ b/app/models/token_auth/configuration_token.rb
@@ -1,7 +1,8 @@
 module TokenAuth
   # A single use human readable token for use with client configuration.
   class ConfigurationToken < ActiveRecord::Base
-    VALID_PERIOD = 4.hours
+    mattr_accessor :valid_period
+    self.valid_period = 4.hours
     SAMPLE_SET = %w( A B C D E F H J K L M N P Q R S T U V W X Y Z
                      2 3 4 5 7 8 9
                      # $ ).freeze
@@ -56,7 +57,7 @@ module TokenAuth
     end
 
     def set_expires_at
-      self.expires_at = Time.zone.now + VALID_PERIOD
+      self.expires_at = Time.zone.now + self.class.valid_period
     end
   end
 end

--- a/app/models/token_auth/payload.rb
+++ b/app/models/token_auth/payload.rb
@@ -21,7 +21,7 @@ module TokenAuth
     end
 
     def save(entities_params)
-      fail MalformedPayloadError unless entities_params.respond_to?(:each)
+      raise MalformedPayloadError unless entities_params.respond_to?(:each)
 
       entities_params.each do |entity_params|
         type = self.class.resource_type(entity_params)

--- a/spec/models/token_auth/configuration_token_spec.rb
+++ b/spec/models/token_auth/configuration_token_spec.rb
@@ -77,7 +77,14 @@ module TokenAuth
 
     describe "initialization" do
       it "sets the expiration date" do
-        expect(create_token!.expires_at).to be > Time.zone.now
+        period = ConfigurationToken.valid_period
+        ConfigurationToken.valid_period = 1.week
+
+        token = create_token!
+        expect(token.expires_at).to be > Time.zone.now + 6.days
+        expect(token.expires_at).to be < Time.zone.now + 8.days
+
+        ConfigurationToken.valid_period = period
       end
 
       it "sets the token value" do

--- a/token_auth.gemspec
+++ b/token_auth.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
                 "README.md"]
 
   s.add_dependency "rails", "~> 4"
-  s.add_dependency "active_model_serializers", "~> 0.10.0.rc3"
+  s.add_dependency "active_model_serializers", "= 0.10.0.rc3"
 
   s.add_development_dependency "pg"
   s.add_development_dependency "rspec-rails", "~> 3.4"


### PR DESCRIPTION
Allow for configurable valid period for config tokens. Fix rubocop offenses. Lock active_model_serializers version.
